### PR TITLE
マイページのカテゴリー等一覧表示UI修正

### DIFF
--- a/app/views/categories/_category_item.html.erb
+++ b/app/views/categories/_category_item.html.erb
@@ -1,6 +1,8 @@
 <%= turbo_frame_tag "category_#{category[1]}" do %>
   <div class="flex items-center justify-between mb-4">
-    <p class="justify-start text-xs sm:text-base ml-2"><%= category[0] %></p>
+    <p class="justify-start text-xs sm:text-base ml-2" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 65%;">
+      <%= category[0] %>
+    </p>
     <div class="justify-end">
       <%= link_to '編集', edit_category_path(category[1]), data: { turbo_frame: "category_#{category[1]}" }, class: "bg-blue-500 hover:bg-blue-700 text-white text-xs sm:text-base font-bold py-2 px-2 rounded" %>
       <%= link_to '削除', category_path(category[1]), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-700 text-white text-xs sm:text-base font-bold py-2 px-2 rounded" %>

--- a/app/views/message_templates/_template.html.erb
+++ b/app/views/message_templates/_template.html.erb
@@ -1,6 +1,8 @@
 <%= turbo_frame_tag "template_#{template[1]}" do %>
   <div class="flex items-center justify-between mb-4">
-    <p class="justify-start text-xs sm:text-base ml-2"><%= template[0] %></p>
+    <p class="justify-start text-xs sm:text-base ml-2" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 65%;">
+      <%= template[0] %>
+    </p>
     <div class="justify-end">
       <%= link_to '編集', edit_message_template_path(template[1]), data: { turbo_frame: "template_#{template[1]}" }, class: "bg-blue-500 hover:bg-blue-700 text-white text-xs sm:text-base font-bold py-2 px-2 rounded" %>
       <%= link_to '削除', message_template_path(template[1]), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-700 text-white text-xs sm:text-base font-bold py-2 px-2 rounded" %>


### PR DESCRIPTION
## 概要

マイページの表示崩れを修正しました

## 確認方法

1. カテゴリーとメッセージテンプレートの部分テンプレートを修正
2. マイページでメッセージテンプレートの文字数が多くても表示が崩れないことを確認ください

## 終了したIssue
Closes #57 